### PR TITLE
zT0Oy9b8: Fix lan scanner

### DIFF
--- a/TVRemoteControl/ScannerTableViewController.swift
+++ b/TVRemoteControl/ScannerTableViewController.swift
@@ -14,7 +14,7 @@ class ScannerTableViewController: UITableViewController {
     private var connectedTVs: [SystemInfo] = []
 
     private lazy var scanner: LANScanner = {
-        LANScanner(lanScanner: MMLANScanner(), trySystemInfoLoader: TrySystemInfoLoader())
+        LANScanner(trySystemInfoLoader: TrySystemInfoLoader())
     }()
 
     override func viewDidLoad() {

--- a/TVRemoteControl/Services/TVScanner/LANScanner.swift
+++ b/TVRemoteControl/Services/TVScanner/LANScanner.swift
@@ -16,16 +16,14 @@ class LANScanner: NSObject {
 
     private let accessQueue = DispatchQueue(label: "IncreaseTVsCount")
 
-    private var lanScanner: MMLANScanner
+    lazy var lanScanner: MMLANScanner = MMLANScanner(delegate: self)
     private let trySystemInfoLoader: TrySystemInfoLoading
 
-    init(lanScanner: MMLANScanner, trySystemInfoLoader: TrySystemInfoLoading) {
-        self.lanScanner = lanScanner
+    init(trySystemInfoLoader: TrySystemInfoLoading) {
         self.trySystemInfoLoader = trySystemInfoLoader
     }
 
     func startScanForPhillipsTV() {
-        lanScanner.delegate = self
         lanScanner.start()
     }
 


### PR DESCRIPTION
MMLANScanner can be initialised only with delegate constructor.
Quick fix in order to be able move forward.
@pryaniq Could you please test it on you LAN? Now, it should find your TV.